### PR TITLE
fix: update SnakeYAML 2.x compatibility for Constructor and Representer

### DIFF
--- a/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
@@ -26,6 +26,7 @@
 package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -37,6 +38,15 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class NucleiModelConstructor extends Constructor {
+
+    NucleiModelConstructor() {
+        super(new LoaderOptions());
+    }
+
+    NucleiModelConstructor(LoaderOptions loaderOptions) {
+        super(loaderOptions);
+    }
+
 
     @Override
     protected Object newInstance(Node node) {

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
@@ -27,6 +27,7 @@ package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.util.YamlPropertyOrder;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -42,6 +43,11 @@ class OrderedRepresenter extends Representer {
     private final PropertyUtils propertyUtils;
 
     OrderedRepresenter(PropertyUtils propertyUtils) {
+        this(propertyUtils, new DumperOptions());
+    }
+
+    OrderedRepresenter(PropertyUtils propertyUtils, DumperOptions dumperOptions) {
+        super(dumperOptions);
         this.propertyUtils = propertyUtils;
     }
 


### PR DESCRIPTION
SnakeYAML 2.x removed no-arg constructors for security reasons. This commit updates:
- NucleiModelConstructor: add super(new LoaderOptions())
- OrderedRepresenter: add super(dumperOptions)

Fixes right-click 'Generate template' not working in Burp Suite 2025.11.x