### PR TITLE
fix snakeyaml 2.x constructor compatibility

### DIFF
--- a/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
@@ -26,6 +26,7 @@
 package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -37,6 +38,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class NucleiModelConstructor extends Constructor {
+
+    NucleiModelConstructor(LoaderOptions loaderOptions) {
+        super(loaderOptions);
+    }
 
     @Override
     protected Object newInstance(Node node) {

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
@@ -27,6 +27,7 @@ package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.util.YamlPropertyOrder;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -41,7 +42,8 @@ class OrderedRepresenter extends Representer {
 
     private final PropertyUtils propertyUtils;
 
-    OrderedRepresenter(PropertyUtils propertyUtils) {
+    OrderedRepresenter(PropertyUtils propertyUtils, DumperOptions dumperOptions) {
+        super(dumperOptions);
         this.propertyUtils = propertyUtils;
     }
 

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
@@ -49,15 +49,15 @@ public final class YamlUtil {
 
     private static Yaml createYamlInstance() {
         final PropertyUtils propertyUtils = new AnnotatedPropertyUtils();
-
-        final BaseConstructor baseConstructor = new NucleiModelConstructor();
-        baseConstructor.setPropertyUtils(propertyUtils);
-
-        final Representer representer = new OrderedRepresenter(propertyUtils);
-        final DumperOptions options = createDumperOptions();
+        final DumperOptions dumperOptions = createDumperOptions();
         final LoaderOptions loaderOptions = new LoaderOptions();
 
-        return new Yaml(baseConstructor, representer, options, loaderOptions);
+        final BaseConstructor baseConstructor = new NucleiModelConstructor(loaderOptions);
+        baseConstructor.setPropertyUtils(propertyUtils);
+
+        final Representer representer = new OrderedRepresenter(propertyUtils, dumperOptions);
+
+        return new Yaml(baseConstructor, representer, dumperOptions, loaderOptions);
     }
 
     private static DumperOptions createDumperOptions() {


### PR DESCRIPTION
Fixes #133

SnakeYAML 2.x removed the no-arg `Constructor()` and `Representer()`, so `main` has not compiled since #128 landed.

Threads the `LoaderOptions` and `DumperOptions` that `YamlUtil` already builds into both subclasses, keeping one source of truth for the dumper settings.

`mvn verify` passes. The four exact-output assertions in `YamlUtilTest` confirm the generated YAML is byte for byte unchanged.

Supersedes #131, which fixed the same two constructors by creating throwaway options inside the subclasses and left two unused overloads behind. Thanks to @kenyon-wong for the report and the diagnosis.
