### PR TITLE
build release jar from the tag instead of pushing to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-java@v6
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,70 +1,43 @@
-name: Java CI
+name: Release
 
 on:
   release:
     types: [ created ]
 
+permissions:
+  contents: write
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
+      - uses: actions/setup-java@v6
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
+          cache: maven
 
-      # Bump patch version and set SNAPSHOT
-      - name: Bump patch version and set SNAPSHOT
-        id: patch_version
-        run: |
-          # Extract the current version from the pom.xml
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "Current version: $VERSION"
+      # The tag is the only source of truth for the released version. Nothing is
+      # committed back to main, so a release can no longer rewrite the branch,
+      # and the artifact can never ship as a SNAPSHOT.
+      - name: Resolve version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-          # Check if the current version already contains SNAPSHOT
-          if [[ "$VERSION" == *-SNAPSHOT ]]; then
-            # Remove the SNAPSHOT suffix for incrementing
-            BASE_VERSION=$(echo $VERSION | sed 's/-SNAPSHOT$//')
-          else
-            # Use the current version as base if it's not a SNAPSHOT
-            BASE_VERSION=$VERSION
-          fi
-
-          # Split the base version into parts and increment the patch version
-          MAJOR=$(echo $BASE_VERSION | cut -d '.' -f 1)
-          MINOR=$(echo $BASE_VERSION | cut -d '.' -f 2)
-          PATCH=$(echo $BASE_VERSION | cut -d '.' -f 3)
-          NEW_PATCH=$((PATCH+1))
-          NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH-SNAPSHOT"
-
-          # Update the version in pom.xml
-          mvn versions:set -DnewVersion=$NEW_VERSION
-          mvn versions:commit
-
-          # Commit the updated pom.xml with the new version
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          git add pom.xml
-          git commit -m "Bump version to $NEW_VERSION"
-          git branch -f main
-          git push origin main
-
-          # Use the new version for the artifact name
-          echo "::set-output name=new_version::$NEW_VERSION"
-
-      - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
-
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+      - name: Build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          mvn --batch-mode org.codehaus.mojo:versions-maven-plugin:2.18.0:set \
+            -DnewVersion="$VERSION" -DgenerateBackupPoms=false
+          mvn --batch-mode verify
+          mv "target/nuclei-burp-plugin-$VERSION-jar-with-dependencies.jar" \
+             "nuclei-burp-plugin-$VERSION.jar"
+
+      - name: Attach jar to release
+        uses: softprops/action-gh-release@v3
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./target/nuclei-burp-plugin-${{ steps.patch_version.outputs.new_version }}-jar-with-dependencies.jar
-          asset_name: nuclei-burp-plugin-${{ steps.patch_version.outputs.new_version }}.jar
-          asset_content_type: application/java-archive
+          files: nuclei-burp-plugin-${{ steps.version.outputs.version }}.jar

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
@@ -26,6 +26,7 @@
 package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -37,6 +38,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class NucleiModelConstructor extends Constructor {
+
+    NucleiModelConstructor(LoaderOptions loaderOptions) {
+        super(loaderOptions);
+    }
 
     @Override
     protected Object newInstance(Node node) {

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
@@ -27,6 +27,7 @@ package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.util.YamlPropertyOrder;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -41,7 +42,8 @@ class OrderedRepresenter extends Representer {
 
     private final PropertyUtils propertyUtils;
 
-    OrderedRepresenter(PropertyUtils propertyUtils) {
+    OrderedRepresenter(PropertyUtils propertyUtils, DumperOptions dumperOptions) {
+        super(dumperOptions);
         this.propertyUtils = propertyUtils;
     }
 

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
@@ -49,15 +49,15 @@ public final class YamlUtil {
 
     private static Yaml createYamlInstance() {
         final PropertyUtils propertyUtils = new AnnotatedPropertyUtils();
-
-        final BaseConstructor baseConstructor = new NucleiModelConstructor();
-        baseConstructor.setPropertyUtils(propertyUtils);
-
-        final Representer representer = new OrderedRepresenter(propertyUtils);
-        final DumperOptions options = createDumperOptions();
+        final DumperOptions dumperOptions = createDumperOptions();
         final LoaderOptions loaderOptions = new LoaderOptions();
 
-        return new Yaml(baseConstructor, representer, options, loaderOptions);
+        final BaseConstructor baseConstructor = new NucleiModelConstructor(loaderOptions);
+        baseConstructor.setPropertyUtils(propertyUtils);
+
+        final Representer representer = new OrderedRepresenter(propertyUtils, dumperOptions);
+
+        return new Yaml(baseConstructor, representer, dumperOptions, loaderOptions);
     }
 
     private static DumperOptions createDumperOptions() {


### PR DESCRIPTION
Fixes #135

Makes the release tag the only source of truth for the version:

- no commit or push back to `main`, so a release can no longer force-move the branch
- the version is set from the tag before the build, so the asset can never be a SNAPSHOT
- `softprops/action-gh-release@v3` replaces the archived `upload-release-asset@v1`
- `$GITHUB_OUTPUT` replaces `::set-output`, and checkout/setup-java move to v7/v6

Verified locally: `versions:set` plus `mvn verify` produces `nuclei-burp-plugin-1.1.4-jar-with-dependencies.jar`, renamed to `nuclei-burp-plugin-1.1.4.jar` to match the existing asset naming.
