### PR TITLE
automate BApp Store submission

### DIFF
--- a/.github/workflows/bapp-submit.yml
+++ b/.github/workflows/bapp-submit.yml
@@ -1,0 +1,67 @@
+name: Submit to BApp Store
+
+# Manual on purpose. PortSwigger asks that a failed submission be fixed and
+# resubmitted on the existing issue rather than opened a second time, so the
+# trigger stays a deliberate action instead of firing on every release.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to submit, without the leading v (e.g. 1.1.4)'
+        required: true
+
+permissions: {}
+
+env:
+  FORK: PortSwigger/nuclei-template-generator
+  PORTAL: PortSwigger/extension-portal
+  BAPP_NAME: Nuclei Template Generator Plugin
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Updates are only accepted from the parent repository of the fork, so the
+      # head is always projectdiscovery:main.
+      - name: Open the update pull request on the PortSwigger fork
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.BAPP_SUBMISSION_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          url=$(gh pr list --repo "$FORK" --base main --state open \
+                            --json url,headRefName,headRepositoryOwner \
+                            --jq '[.[] | select(.headRefName == "main" and .headRepositoryOwner.login == "projectdiscovery")][0].url // empty')
+          if [ -z "$url" ]; then
+            url=$(gh pr create --repo "$FORK" --base main --head projectdiscovery:main \
+                               --title "v$VERSION" --body "Release v$VERSION of $BAPP_NAME.")
+          else
+            echo "Reusing the open pull request: $url"
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # The portal parses the body literally: '### ' headings, value on the next
+      # line but one. See https://github.com/PortSwigger/extension-portal/blob/main/AGENTS.md
+      - name: Submit the update to the extension portal
+        env:
+          GH_TOKEN: ${{ secrets.BAPP_SUBMISSION_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          set -euo pipefail
+          summary=$(gh release view "v$VERSION" --json body --jq '.body // empty')
+          : "${summary:=Release v$VERSION.}"
+
+          {
+            printf '### Pull request URL\n\n%s\n\n' "$PR_URL"
+            printf '### Version number\n\n%s\n\n' "$VERSION"
+            printf '### Author display name\n\n_No response_\n\n'
+            printf '### Contact Details\n\n_No response_\n\n'
+            printf '### Discord username\n\n_No response_\n\n'
+            printf '### Update summary\n\n%s\n\n' "$summary"
+            printf '### BApp Description update\n\n_No response_\n'
+          } > update.md
+
+          gh issue create --repo "$PORTAL" --title "$BAPP_NAME" --body-file update.md

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,32 @@
+# Releasing
+
+## 1. Cut the GitHub release
+
+Create a release with a `v`-prefixed tag (e.g. `v1.1.4`). The tag is the source
+of truth for the version, so nothing needs to be committed to `main` first.
+
+`.github/workflows/ci.yml` builds the shaded jar at that version and attaches
+`nuclei-burp-plugin-<version>.jar` to the release.
+
+## 2. Submit to the BApp Store
+
+Run the **Submit to BApp Store** workflow and give it the version (e.g. `1.1.4`).
+It performs both steps PortSwigger requires:
+
+1. Opens a pull request on [`PortSwigger/nuclei-template-generator`](https://github.com/PortSwigger/nuclei-template-generator)
+   from `projectdiscovery:main`. Updates are only accepted from the parent
+   repository of that fork.
+2. Opens an update submission issue on
+   [`PortSwigger/extension-portal`](https://github.com/PortSwigger/extension-portal)
+   linking that pull request.
+
+The portal comments on the issue within a few minutes. On failure, fix the
+problem and comment `/resubmit` on that same issue. Do not open a second one.
+
+Emailing bapps@portswigger.net is no longer part of the process; the portal
+replaced it.
+
+### Required secret
+
+`BAPP_SUBMISSION_TOKEN`: a PAT with the `public_repo` scope. `GITHUB_TOKEN`
+cannot be used because both steps act on repositories outside this one.

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
@@ -26,6 +26,7 @@
 package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -37,6 +38,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class NucleiModelConstructor extends Constructor {
+
+    NucleiModelConstructor(LoaderOptions loaderOptions) {
+        super(loaderOptions);
+    }
 
     @Override
     protected Object newInstance(Node node) {

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
@@ -27,6 +27,7 @@ package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.util.YamlPropertyOrder;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -41,7 +42,8 @@ class OrderedRepresenter extends Representer {
 
     private final PropertyUtils propertyUtils;
 
-    OrderedRepresenter(PropertyUtils propertyUtils) {
+    OrderedRepresenter(PropertyUtils propertyUtils, DumperOptions dumperOptions) {
+        super(dumperOptions);
         this.propertyUtils = propertyUtils;
     }
 

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
@@ -49,15 +49,15 @@ public final class YamlUtil {
 
     private static Yaml createYamlInstance() {
         final PropertyUtils propertyUtils = new AnnotatedPropertyUtils();
-
-        final BaseConstructor baseConstructor = new NucleiModelConstructor();
-        baseConstructor.setPropertyUtils(propertyUtils);
-
-        final Representer representer = new OrderedRepresenter(propertyUtils);
-        final DumperOptions options = createDumperOptions();
+        final DumperOptions dumperOptions = createDumperOptions();
         final LoaderOptions loaderOptions = new LoaderOptions();
 
-        return new Yaml(baseConstructor, representer, options, loaderOptions);
+        final BaseConstructor baseConstructor = new NucleiModelConstructor(loaderOptions);
+        baseConstructor.setPropertyUtils(propertyUtils);
+
+        final Representer representer = new OrderedRepresenter(propertyUtils, dumperOptions);
+
+        return new Yaml(baseConstructor, representer, dumperOptions, loaderOptions);
     }
 
     private static DumperOptions createDumperOptions() {


### PR DESCRIPTION
Fixes #120

PortSwigger replaced the pull-request-plus-email process with https://github.com/PortSwigger/extension-portal, which parses a structured submission issue. Their `AGENTS.md` documents the exact body format, so this is now automatable.

Adds a `workflow_dispatch` workflow that does both steps they require:

1. opens the update pull request on `PortSwigger/nuclei-template-generator` from `projectdiscovery:main`, reusing one that is already open
2. opens the portal submission issue linking that pull request, with the body matching their spec exactly

Manual trigger on purpose: PortSwigger asks that a failed submission be fixed and resubmitted on the same issue, so firing automatically on every release would work against that.

Needs a `BAPP_SUBMISSION_TOKEN` secret, a PAT with the `public_repo` scope. `GITHUB_TOKEN` cannot act on repositories outside this one.

`RELEASING.md` documents the end to end flow.
