### PR TITLE
modernize the build to Java 17 and current dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,22 +43,21 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>11</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <java.version>17</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
 
-        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+        <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
 
         <burp-extender-api.version>2.3</burp-extender-api.version>
-        <snakeyaml.version>2.5</snakeyaml.version>
-        <gson.version>2.10.1</gson.version>
-        <rsyntaxtextarea.version>3.3.4</rsyntaxtextarea.version>
-        <autocomplete.version>3.3.1</autocomplete.version>
+        <snakeyaml.version>2.7</snakeyaml.version>
+        <gson.version>2.14.0</gson.version>
+        <rsyntaxtextarea.version>4.0.1</rsyntaxtextarea.version>
+        <autocomplete.version>4.0.0</autocomplete.version>
 
-        <junit-jupiter.version>5.11.0</junit-jupiter.version>
-        <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
+        <junit-jupiter.version>6.1.3</junit-jupiter.version>
+        <maven-surefire-plugin.version>3.6.0</maven-surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -94,7 +93,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.1.0</version>
+            <version>26.1.0</version>
         </dependency>
 
         <dependency>
@@ -112,12 +111,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <fork>true</fork>
-                    <optimize>true</optimize>
                     <showDeprecation>true</showDeprecation>
-                    <verbose>true</verbose>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/NucleiModelConstructor.java
@@ -26,6 +26,7 @@
 package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.*;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -37,6 +38,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 class NucleiModelConstructor extends Constructor {
+
+    NucleiModelConstructor(LoaderOptions loaderOptions) {
+        super(loaderOptions);
+    }
 
     @Override
     protected Object newInstance(Node node) {

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/OrderedRepresenter.java
@@ -27,6 +27,7 @@ package io.projectdiscovery.nuclei.yaml;
 
 import io.projectdiscovery.nuclei.model.util.YamlPropertyOrder;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.MappingNode;
@@ -41,7 +42,8 @@ class OrderedRepresenter extends Representer {
 
     private final PropertyUtils propertyUtils;
 
-    OrderedRepresenter(PropertyUtils propertyUtils) {
+    OrderedRepresenter(PropertyUtils propertyUtils, DumperOptions dumperOptions) {
+        super(dumperOptions);
         this.propertyUtils = propertyUtils;
     }
 

--- a/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
+++ b/src/main/java/io/projectdiscovery/nuclei/yaml/YamlUtil.java
@@ -49,15 +49,15 @@ public final class YamlUtil {
 
     private static Yaml createYamlInstance() {
         final PropertyUtils propertyUtils = new AnnotatedPropertyUtils();
-
-        final BaseConstructor baseConstructor = new NucleiModelConstructor();
-        baseConstructor.setPropertyUtils(propertyUtils);
-
-        final Representer representer = new OrderedRepresenter(propertyUtils);
-        final DumperOptions options = createDumperOptions();
+        final DumperOptions dumperOptions = createDumperOptions();
         final LoaderOptions loaderOptions = new LoaderOptions();
 
-        return new Yaml(baseConstructor, representer, options, loaderOptions);
+        final BaseConstructor baseConstructor = new NucleiModelConstructor(loaderOptions);
+        baseConstructor.setPropertyUtils(propertyUtils);
+
+        final Representer representer = new OrderedRepresenter(propertyUtils, dumperOptions);
+
+        return new Yaml(baseConstructor, representer, dumperOptions, loaderOptions);
     }
 
     private static DumperOptions createDumperOptions() {


### PR DESCRIPTION
Fixes #137

Supersedes #125, #126, #127, #129 and #130.

- Java 11 -> 17, with `maven.compiler.release` instead of `source`/`target`
- rsyntaxtextarea 3.3.4 -> 4.0.1, autocomplete 3.3.1 -> 4.0.0, snakeyaml 2.5 -> 2.7, gson 2.10.1 -> 2.14.0, annotations 24.1.0 -> 26.1.0, junit-jupiter 5.11.0 -> 6.1.3
- compiler plugin 3.14.1, surefire 3.6.0, assembly 3.8.0
- drops the `fork`, `optimize` and `verbose` compiler flags, which only added build noise

The RSyntaxTextArea and AutoComplete major bumps were smoke tested at runtime, not just compiled: theme load, the custom `NucleiTokenMaker`, tokenisation, autocomplete install and `RTextScrollPane` all work, and the hardcoded `themes/dark.xml` resource path still exists in 4.x.

Java 17 bytecode needs Burp on a Java 17 or newer runtime. Burp 2025.x and later bundle Java 21.
