### PR TITLE
read the release notes from this repository

### DIFF
--- a/.github/workflows/bapp-submit.yml
+++ b/.github/workflows/bapp-submit.yml
@@ -51,7 +51,7 @@ jobs:
           PR_URL: ${{ steps.pr.outputs.url }}
         run: |
           set -euo pipefail
-          summary=$(gh release view "v$VERSION" --json body --jq '.body // empty')
+          summary=$(gh release view "v$VERSION" --repo "$GITHUB_REPOSITORY" --json body --jq '.body // empty')
           : "${summary:=Release v$VERSION.}"
 
           {


### PR DESCRIPTION
Fixes #150

`gh release view` had no `--repo` and the job does not check out, so it had no repository context.
