### PR TITLE
use the pdteamx org secret for BApp submission

### DIFF
--- a/.github/workflows/bapp-submit.yml
+++ b/.github/workflows/bapp-submit.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Open the update pull request on the PortSwigger fork
         id: pr
         env:
-          GH_TOKEN: ${{ secrets.BAPP_SUBMISSION_TOKEN }}
+          GH_TOKEN: ${{ secrets.PDTEAMX_CLASSIC_PAT }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -46,7 +46,7 @@ jobs:
       # line but one. See https://github.com/PortSwigger/extension-portal/blob/main/AGENTS.md
       - name: Submit the update to the extension portal
         env:
-          GH_TOKEN: ${{ secrets.BAPP_SUBMISSION_TOKEN }}
+          GH_TOKEN: ${{ secrets.PDTEAMX_CLASSIC_PAT }}
           VERSION: ${{ inputs.version }}
           PR_URL: ${{ steps.pr.outputs.url }}
         run: |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,10 @@ problem and comment `/resubmit` on that same issue. Do not open a second one.
 Emailing bapps@portswigger.net is no longer part of the process; the portal
 replaced it.
 
-### Required secret
+### Token
 
-`BAPP_SUBMISSION_TOKEN`: a PAT with the `public_repo` scope. `GITHUB_TOKEN`
-cannot be used because both steps act on repositories outside this one.
+Uses the organisation secret `PDTEAMX_CLASSIC_PAT`, so there is nothing to set up.
+
+It has to be a classic PAT belonging to an account outside PortSwigger, because
+both steps act on repositories in another organisation. `GITHUB_TOKEN` cannot be
+used: its permissions are limited to the repository containing the workflow.


### PR DESCRIPTION
Fixes #152

Uses the existing `PDTEAMX_CLASSIC_PAT` org secret instead of a secret that was never created. Nothing to set up.

`GITHUB_TOKEN` cannot be used here: its permissions are limited to the repository containing the workflow, and this writes to two PortSwigger repos.
